### PR TITLE
Testing cleaner TalonSRX configuration and MotionMagic

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -36,13 +36,17 @@ public final class Constants {
     public static final double kNeutralDeadband = 0.001;
     public static final int kLoopTimeMs = 1;
     public static final int kAllowableCloseLoopError = 25;
+    public static final double kOpenLoopRampRate = 0.3;
+    public static final int kContinuousCurrent = 20;
+    public static final int kMotionCruiseVelocity = 1500;
+    public static final int kMotionAcceleration = 750;
 
     // Drive Train gains and max speed
     public static final double kDriveAbsMax = 0.7;
-    public static final Gains kDriveGains = new Gains(0.002, 0, 0, 0.35, 0, 0);
-    public static final Gains kTurnGains = new Gains(0.004, 0, 0, 0, 0, 0);
-    public static final Gains kVelGains = new Gains(0, 0, 0, 0, 0, 0);
-    public static final Gains kMotProfGains = new Gains(0, 0, 0, 0, 0, 0);
+    public static final Gains kDriveGains = new Gains(0.0016, 0, 0, 0.35, 100, 1.0);
+    public static final Gains kTurnGains = new Gains(0.004,   0, 0, 0.35, 200, 1.0);
+    public static final Gains kVelGains = new Gains(0,        0, 0, 0.00, 300, 1.0);
+    public static final Gains kMotProfGains = new Gains(0,    0, 0, 0.35, 400, 1.0);
 
     // Controllers and deadbands
     public static final int kDRIVER_CONTROLLER = 0;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,7 +11,7 @@ import frc.robot.commands.drive_train.DriveMMTest;
 import frc.robot.commands.drive_train.TurnToAngle;
 import frc.robot.commands.drive_train.TurnToAngleTest;
 import frc.robot.commands.drive_train.UpdateDriveLimiters;
-import frc.robot.subsystems.DriveTrain;
+import frc.robot.subsystems.DriveTrainTalonSRX;
 
 import static frc.robot.Constants.*;
 
@@ -19,7 +19,7 @@ import static frc.robot.Constants.*;
 public class RobotContainer {
 
   //Subsystems
-  DriveTrain m_driveTrain;
+  DriveTrainTalonSRX m_driveTrain;
 
   //OI
   Joystick m_driverController;
@@ -32,7 +32,7 @@ public class RobotContainer {
     m_driverController = new Joystick(kDRIVER_CONTROLLER);
 
     //Subsystems
-    m_driveTrain = new DriveTrain();
+    m_driveTrain = new DriveTrainTalonSRX();
 
     //Default Commands
     m_driveTrain.setDefaultCommand(new DriveTrainDefaultCommand(m_driveTrain, m_driverController));

--- a/src/main/java/frc/robot/commands/autonomous/MotionMagicDriveTest.java
+++ b/src/main/java/frc/robot/commands/autonomous/MotionMagicDriveTest.java
@@ -2,13 +2,13 @@ package frc.robot.commands.autonomous;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.drive_train.DriveMMTest;
-import frc.robot.subsystems.DriveTrain;
+import frc.robot.subsystems.DriveTrainTalonSRX;
 
 public class MotionMagicDriveTest extends SequentialCommandGroup {
 
-    DriveTrain m_driveTrain;
+    DriveTrainTalonSRX m_driveTrain;
 
-    public MotionMagicDriveTest(DriveTrain driveTrain) {
+    public MotionMagicDriveTest(DriveTrainTalonSRX driveTrain) {
 
         m_driveTrain = driveTrain;
 

--- a/src/main/java/frc/robot/commands/default_commands/DriveTrainDefaultCommand.java
+++ b/src/main/java/frc/robot/commands/default_commands/DriveTrainDefaultCommand.java
@@ -2,14 +2,14 @@ package frc.robot.commands.default_commands;
 
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.subsystems.DriveTrain;
+import frc.robot.subsystems.DriveTrainTalonSRX;
 
 public class DriveTrainDefaultCommand extends CommandBase{
 
-    private final DriveTrain m_driveTrain;
+    private final DriveTrainTalonSRX m_driveTrain;
     private final Joystick m_driverController;
 
-    public DriveTrainDefaultCommand(DriveTrain driveTrain, Joystick driverController) {
+    public DriveTrainDefaultCommand(DriveTrainTalonSRX driveTrain, Joystick driverController) {
         m_driveTrain = driveTrain;
         m_driverController = driverController;
 

--- a/src/main/java/frc/robot/commands/drive_train/DriveMM.java
+++ b/src/main/java/frc/robot/commands/drive_train/DriveMM.java
@@ -1,18 +1,18 @@
 package frc.robot.commands.drive_train;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.subsystems.DriveTrain;
+import frc.robot.subsystems.DriveTrainTalonSRX;
 
 import static frc.robot.Constants.*;
 
 public class DriveMM extends CommandBase {
 
-    DriveTrain m_driveTrain;
+    DriveTrainTalonSRX m_driveTrain;
 
     double m_targetPosition;
     int m_count, STABLE_ITERATIONS_BEFORE_FINISHED = 5;
 
-    public DriveMM(DriveTrain driveTrain, double targetInches) {
+    public DriveMM(DriveTrainTalonSRX driveTrain, double targetInches) {
 
         m_driveTrain = driveTrain;
 
@@ -29,15 +29,13 @@ public class DriveMM extends CommandBase {
     @Override
     public void initialize() {
 
-        m_driveTrain.motionMagicStartConfigDrive(m_targetPosition >= 0, m_targetPosition);
+        m_driveTrain.motionMagicStartConfigDrive( m_targetPosition);
 
     }
 
     @Override
     public void execute() {
 
-        m_driveTrain.feedWatchdog();
-        
         if (m_driveTrain.motionMagicDrive(m_targetPosition)) {
             m_count++;
         } else {

--- a/src/main/java/frc/robot/commands/drive_train/DriveMMTest.java
+++ b/src/main/java/frc/robot/commands/drive_train/DriveMMTest.java
@@ -1,16 +1,17 @@
 package frc.robot.commands.drive_train;
 
+import static frc.robot.Constants.kEncoderTicksPerInch;
+
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.subsystems.DriveTrain;
-import static frc.robot.Constants.*;
+import frc.robot.subsystems.DriveTrainTalonSRX;
 
 public class DriveMMTest extends CommandBase{
 
-    DriveTrain m_driveTrain;
+    DriveTrainTalonSRX m_driveTrain;
     ShuffleboardTab m_driveMMTab;
     double m_targetPosition;
     double m_targetTicks;
@@ -20,7 +21,7 @@ public class DriveMMTest extends CommandBase{
     NetworkTableEntry m_kpEntry, m_kiEntry, m_kdEntry, m_kfEntry, m_targetPosEntry, m_targetTicksEntry, m_iterationEntry, m_driveDurationEntry;
     int STABLE_ITERATIONS_BEFORE_FINISHED = 5;
 
-    public DriveMMTest(DriveTrain driveTrain, double targetInches) {
+    public DriveMMTest(DriveTrainTalonSRX driveTrain, double targetInches) {
 
         m_driveTrain = driveTrain;
         m_targetPosition = targetInches;
@@ -48,11 +49,12 @@ public class DriveMMTest extends CommandBase{
         m_targetTicksEntry.forceSetDouble((int) m_targetTicks);
         m_count = 0;
         m_driveTrain.resetDrivePIDValues(m_kpEntry.getDouble(0.0), m_kiEntry.getDouble(0.0), m_kfEntry.getDouble(0), m_kfEntry.getDouble(0));
-        m_driveTrain.motionMagicStartConfigDrive(m_targetTicks >= 0, m_targetTicks);
+        m_driveTrain.motionMagicStartConfigDrive( m_targetTicks);
     }
 
     @Override
     public void execute() {
+
         
         if (m_driveTrain.motionMagicDrive(m_targetTicks)) {
             m_count++;

--- a/src/main/java/frc/robot/commands/drive_train/TurnToAngle.java
+++ b/src/main/java/frc/robot/commands/drive_train/TurnToAngle.java
@@ -1,19 +1,19 @@
 package frc.robot.commands.drive_train;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.subsystems.DriveTrain;
+import frc.robot.subsystems.DriveTrainTalonSRX;
 
 import static frc.robot.Constants.*;
 
 public class TurnToAngle extends CommandBase {
 
-    DriveTrain m_driveTrain;
+    DriveTrainTalonSRX m_driveTrain;
 
     double m_tolerance, m_arcLengthTicks;
     int STABLE_ITERATIONS_BEFORE_FINISHED = 5;
     double m_count = 0;
     
-    public TurnToAngle(DriveTrain driveTrain, double angle) {
+    public TurnToAngle(DriveTrainTalonSRX driveTrain, double angle) {
 
         m_driveTrain = driveTrain;
         m_arcLengthTicks = angle * kEncoderTicksPerDegree;

--- a/src/main/java/frc/robot/commands/drive_train/TurnToAngleTest.java
+++ b/src/main/java/frc/robot/commands/drive_train/TurnToAngleTest.java
@@ -5,13 +5,13 @@ import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.subsystems.DriveTrain;
+import frc.robot.subsystems.DriveTrainTalonSRX;
 
 import static frc.robot.Constants.*;
 
 public class TurnToAngleTest extends CommandBase {
 
-    DriveTrain m_driveTrain;
+    DriveTrainTalonSRX m_driveTrain;
 
     public static double m_currentAngle;
     double m_targetAngle, m_tolerance, m_speed, m_arcLengthTicks;
@@ -20,7 +20,7 @@ public class TurnToAngleTest extends CommandBase {
     private NetworkTableEntry m_turnKpEntry, m_turnKiEntry, m_turnKdEntry, m_turnKfEntry, m_arcLengthEntry, m_iterationEntry, m_driveDurationEntry, m_arcLengthTicksEntry;
     int STABLE_ITERATIONS_BEFORE_FINISHED = 5;
 
-    public TurnToAngleTest(DriveTrain driveTrain, double angle) {
+    public TurnToAngleTest(DriveTrainTalonSRX driveTrain, double angle) {
 
         m_driveTrain = driveTrain;
         m_targetAngle = angle;

--- a/src/main/java/frc/robot/commands/drive_train/UpdateDriveLimiters.java
+++ b/src/main/java/frc/robot/commands/drive_train/UpdateDriveLimiters.java
@@ -1,13 +1,13 @@
 package frc.robot.commands.drive_train;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
-import frc.robot.subsystems.DriveTrain;
+import frc.robot.subsystems.DriveTrainTalonSRX;
 
 public class UpdateDriveLimiters  extends InstantCommand{
 
-    DriveTrain m_driveTrain;
+    DriveTrainTalonSRX m_driveTrain;
 
-    public UpdateDriveLimiters(DriveTrain driveTrain) {
+    public UpdateDriveLimiters(DriveTrainTalonSRX driveTrain) {
 
         m_driveTrain = driveTrain;
 

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -218,6 +218,8 @@ public class DriveTrain extends SubsystemBase{
         }
     }
 
+
+	@SuppressWarnings("unused")
     private double clamp(double value) {
         if (value >= m_driveAbsMax){
             return m_driveAbsMax;

--- a/src/main/java/frc/robot/subsystems/DriveTrainNew.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrainNew.java
@@ -1,10 +1,22 @@
 package frc.robot.subsystems;
 
-import static frc.robot.Constants.kEncoderUnitsPerRotation;
+import static frc.robot.Constants.k100msPerSecond;
+import static frc.robot.Constants.kCountsPerRevolution;
+import static frc.robot.Constants.kDriveGains;
+import static frc.robot.Constants.kDriverDeadband;
 import static frc.robot.Constants.kGearRatio;
+import static frc.robot.Constants.kLEFT_FOLLOWER;
+import static frc.robot.Constants.kLEFT_LEADER;
 import static frc.robot.Constants.kNeutralDeadband;
+import static frc.robot.Constants.kPID_PRIMARY;
+import static frc.robot.Constants.kRIGHT_FOLLOWER;
+import static frc.robot.Constants.kRIGHT_LEADER;
+import static frc.robot.Constants.kSlotDrive;
+import static frc.robot.Constants.kSlotTurning;
 import static frc.robot.Constants.kTimeoutMs;
-import static frc.robot.Constants.kTurnTravelUnitsPerRotation;
+import static frc.robot.Constants.kTrackWidthMeters;
+import static frc.robot.Constants.kTurnGains;
+import static frc.robot.Constants.kWheelDiameterMeters;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.InvertType;
@@ -23,7 +35,6 @@ import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;
 import edu.wpi.first.math.system.plant.DCMotor;
-import edu.wpi.first.math.util.Units;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -35,8 +46,6 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Robot;
-
-import static frc.robot.Constants.*;
 
 public class DriveTrainNew extends SubsystemBase {
 	private final double MAX_TELEOP_DRIVE_SPEED = .70;
@@ -78,7 +87,6 @@ public class DriveTrainNew extends SubsystemBase {
 
 	// Motion Magic Setpoints for each side of the motor
 	private double m_left_setpoint, m_right_setpoint;
-	private boolean m_isCCWTurn;
 
   	/** Creates a new DriveTrain. */
  	public DriveTrainNew() {
@@ -546,6 +554,7 @@ public class DriveTrainNew extends SubsystemBase {
 		angle.set(-m_drivetrainSimulator.getHeading().getDegrees());
 	}
 
+	@SuppressWarnings("unused")
 	private int distanceToNativeUnits(double positionMeters){
 		double wheelRotations = positionMeters/(2 * Math.PI * (kWheelDiameterMeters / 2));
 		double motorRotations = wheelRotations * kGearRatio;
@@ -553,6 +562,8 @@ public class DriveTrainNew extends SubsystemBase {
 		return sensorCounts;
 	}
 
+
+	@SuppressWarnings("unused")
 	private int velocityToNativeUnits(double velocityMetersPerSecond){
 		double wheelRotationsPerSecond = velocityMetersPerSecond/(2 * Math.PI * (kWheelDiameterMeters / 2));
 		double motorRotationsPerSecond = wheelRotationsPerSecond * kGearRatio;
@@ -561,6 +572,8 @@ public class DriveTrainNew extends SubsystemBase {
 		return sensorCountsPer100ms;
 	}
 
+
+	@SuppressWarnings("unused")
 	private double nativeUnitsToDistanceMeters(double sensorCounts){
 		double motorRotations = (double)sensorCounts / kCountsPerRevolution;
 		double wheelRotations = motorRotations / kGearRatio;

--- a/src/main/java/frc/robot/subsystems/DriveTrainTalonSRX.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrainTalonSRX.java
@@ -1,0 +1,322 @@
+package frc.robot.subsystems;
+
+import static frc.robot.Constants.kAllowableCloseLoopError;
+import static frc.robot.Constants.kContinuousCurrent;
+import static frc.robot.Constants.kDriveGains;
+import static frc.robot.Constants.kDriverDeadband;
+import static frc.robot.Constants.kLEFT_FOLLOWER;
+import static frc.robot.Constants.kLEFT_LEADER;
+import static frc.robot.Constants.kMotionAcceleration;
+import static frc.robot.Constants.kMotionCruiseVelocity;
+import static frc.robot.Constants.kNeutralDeadband;
+import static frc.robot.Constants.kOpenLoopRampRate;
+import static frc.robot.Constants.kPID_PRIMARY;
+import static frc.robot.Constants.kPID_TURN;
+import static frc.robot.Constants.kRIGHT_FOLLOWER;
+import static frc.robot.Constants.kRIGHT_LEADER;
+import static frc.robot.Constants.kSlotDrive;
+import static frc.robot.Constants.kSlotTurning;
+import static frc.robot.Constants.kTimeoutMs;
+import static frc.robot.Constants.kTurnGains;
+
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.FeedbackDevice;
+import com.ctre.phoenix.motorcontrol.InvertType;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.StatusFrame;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
+import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
+import com.ctre.phoenix.motorcontrol.can.TalonSRXConfiguration;
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.kauailabs.navx.frc.AHRS;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.SerialPort;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class DriveTrainTalonSRX extends SubsystemBase{
+
+    private WPI_TalonSRX m_leftLeader, m_leftFollower, m_rightLeader, m_rightFollower;
+
+    private AHRS m_gyro;
+
+    private DifferentialDrive m_diffDrive;
+
+    // Creates a variable for Open Loop Ramp value a.k.a. Slew Rate.
+    // This is for tuning purposes. After tuned, update the kSecondsFromNeutral variable on Constants.java
+    private double m_secondsFromNeutral, m_driveAbsMax;
+    NetworkTableEntry m_secondsFromNeutralEntry, m_driveAbsMaxEntry;
+
+    //Motion Magic set points
+    private double m_leftSetpoint, m_rightSetpoint;
+
+    public DriveTrainTalonSRX() {
+
+        m_rightLeader = new WPI_TalonSRX(kRIGHT_LEADER);
+        m_rightFollower = new WPI_TalonSRX(kRIGHT_FOLLOWER);
+        m_leftLeader  = new WPI_TalonSRX(kLEFT_LEADER);
+        m_leftFollower = new WPI_TalonSRX(kLEFT_FOLLOWER);
+        TalonSRXConfiguration config = new TalonSRXConfiguration();
+
+        // Factory default the talons
+        m_rightLeader.configAllSettings(config);
+        m_rightFollower.configAllSettings(config);
+
+         // Set all the configuration values that are common across
+        // both sides of the drivetrain
+        config.openloopRamp = kOpenLoopRampRate;
+        config.continuousCurrentLimit = kContinuousCurrent;
+        config.nominalOutputForward = 0;
+        config.nominalOutputReverse = 0;
+        config.peakOutputForward = 1;
+        config.peakOutputReverse = -1;
+        config.neutralDeadband = kNeutralDeadband;
+        config.slot0.kF = kDriveGains.kF;
+        config.slot0.kP = kDriveGains.kP;
+        config.slot0.kI = kDriveGains.kI;
+        config.slot0.kD = kDriveGains.kD;
+        config.slot0.integralZone = kDriveGains.kIzone;
+        config.slot0.closedLoopPeakOutput = kDriveGains.kPeakOutput;
+        config.slot0.allowableClosedloopError = 10;
+        config.slot0.closedLoopPeriod = 1; // 1 ms loop
+        config.slot1.kF = kTurnGains.kF;
+        config.slot1.kP = kTurnGains.kP;
+        config.slot1.kI = kTurnGains.kI;
+        config.slot1.kD = kTurnGains.kD;
+        config.slot1.allowableClosedloopError = 10;
+        config.slot1.integralZone = kTurnGains.kIzone;
+        config.slot1.closedLoopPeakOutput = kTurnGains.kPeakOutput;
+        config.slot1.closedLoopPeriod = 1; // 1 ms
+        config.motionCruiseVelocity = kMotionCruiseVelocity;
+        config.motionAcceleration = kMotionAcceleration;
+        m_rightLeader.configAllSettings(config);
+        m_leftLeader.configAllSettings(config);
+
+        // Set the followers and inverts
+        m_leftLeader.setInverted(true);
+        m_leftLeader.setSensorPhase(true);
+        m_rightLeader.setInverted(false);
+        m_rightLeader.setSensorPhase(false);
+        m_rightFollower.follow(m_rightLeader);
+        m_rightFollower.setInverted(InvertType.FollowMaster);
+        m_leftFollower.follow(m_leftLeader);
+        m_leftFollower.setInverted(InvertType.FollowMaster);
+  
+        // Neutral Mode to Help slow things down
+        m_rightLeader.setNeutralMode(NeutralMode.Brake);
+        m_leftLeader.setNeutralMode(NeutralMode.Brake);
+
+        // Setup quadrature as primary encoder for PID driving
+        m_rightLeader.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder, kPID_PRIMARY, 0);
+        m_leftLeader.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder, kPID_PRIMARY, 0);
+        m_rightLeader.setSelectedSensorPosition(0, kSlotDrive, 0);
+        m_leftLeader.setSelectedSensorPosition(0, kSlotDrive, 0);
+    
+        // select profile slot
+        m_leftLeader.selectProfileSlot(kSlotDrive, kPID_PRIMARY);
+        m_rightLeader.selectProfileSlot(kSlotDrive, kPID_PRIMARY);
+    
+        // We have observed a couple times where the robot loses control and continues without operator
+        // input, changed the TalonSRX objects to be WPI_Talons so we can use the differential drive.
+        // We aren't going to actually drive with it.  We are just going to use it for the Watchdog timer.
+        m_diffDrive = new DifferentialDrive(m_leftLeader, m_rightLeader);
+
+        //Creates a gyro
+        try{
+            m_gyro = new AHRS(SerialPort.Port.kUSB1);
+            m_gyro.enableLogging(true);
+        } catch (RuntimeException ex) {
+            DriverStation.reportError("Error instantiating navX" + ex.getMessage(), true);
+        }
+
+        /* Set status frame periods */
+		m_rightLeader.setStatusFramePeriod(StatusFrame.Status_12_Feedback1, 20, kTimeoutMs);
+		m_rightLeader.setStatusFramePeriod(StatusFrame.Status_14_Turn_PIDF1, 20, kTimeoutMs);
+		m_leftLeader.setStatusFramePeriod(StatusFrame.Status_2_Feedback0, 5, kTimeoutMs);		//Used remotely by right Talon, speed up
+
+        m_leftLeader.setStatusFramePeriod(StatusFrameEnhanced.Status_13_Base_PIDF0, 10, kTimeoutMs);
+        m_leftLeader.setStatusFramePeriod(StatusFrameEnhanced.Status_10_MotionMagic, 10, kTimeoutMs);
+        m_rightLeader.setStatusFramePeriod(StatusFrameEnhanced.Status_13_Base_PIDF0, 10, kTimeoutMs);
+        m_rightLeader.setStatusFramePeriod(StatusFrameEnhanced.Status_10_MotionMagic, 10, kTimeoutMs);
+
+    
+        m_leftLeader.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 35, 40, 1.0), 0);
+        m_rightLeader.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 35, 40, 1.0), 0);
+
+      
+        // Tuning Params //
+
+        NetworkTable m_driveTestTable = NetworkTableInstance.getDefault().getTable("Shuffleboard").getSubTable("Drive Testing");
+
+        m_driveAbsMaxEntry = m_driveTestTable.getEntry("Drive Max");
+        m_secondsFromNeutralEntry = m_driveTestTable.getEntry("Forward Limiter");
+        m_gyro.reset();
+
+        // End of Tuning Params //
+
+    }
+
+    // Encoder methods
+    public void resetEncoders() {
+        m_leftLeader.setSelectedSensorPosition(0,kPID_PRIMARY,0);
+        m_rightLeader.setSelectedSensorPosition(0,kPID_PRIMARY,0);
+    }
+
+    public double getLeftEncoderPosition() {
+        return m_leftLeader.getSelectedSensorPosition();
+    }
+
+    public double getRightEncoderPosition() {
+        return m_leftLeader.getSelectedSensorPosition();
+    }
+
+    // Gyro methods
+    public double getHeading() {
+        return Math.IEEEremainder(m_gyro.getAngle(), 360);
+    }
+
+    public double getRawAngle() {
+        return m_gyro.getAngle();
+    }
+
+    public AHRS getGyro() {
+        return m_gyro;
+    }
+
+    // 
+
+    // Drive Train Methods
+    private double deadband(double value) {
+        if (Math.abs(value) >= kDriverDeadband) {
+            return value;
+        } else {
+            return 0;
+        }
+    }
+
+
+	@SuppressWarnings("unused")
+    private double clamp(double value) {
+        if (value >= m_driveAbsMax){
+            return m_driveAbsMax;
+        } 
+        
+        if (value <= -m_driveAbsMax) {
+            return -m_driveAbsMax;
+        }
+
+        return value;
+    }
+
+    public void teleopDrive(double speedValue, double rotationValue, boolean isSquared) {
+        m_diffDrive.arcadeDrive(deadband(speedValue), deadband(-rotationValue), isSquared);
+    }
+
+    public void teleopDrive(double speedValue, double rotationValue) {
+        m_diffDrive.arcadeDrive(deadband(speedValue), deadband(-rotationValue));
+    }
+
+    public void motionMagicStartConfigDrive(double lengthInTicks) {
+        resetEncoders();
+
+        m_leftLeader.configMotionCruiseVelocity(kMotionCruiseVelocity, kTimeoutMs);
+        m_leftLeader.configMotionAcceleration(kMotionAcceleration, kTimeoutMs);
+        m_rightLeader.configMotionCruiseVelocity(kMotionCruiseVelocity, kTimeoutMs);
+        m_rightLeader.configMotionAcceleration(kMotionAcceleration, kTimeoutMs);
+
+        m_leftLeader.selectProfileSlot(kSlotDrive, kPID_PRIMARY);
+        m_rightLeader.selectProfileSlot(kSlotDrive, kPID_PRIMARY);
+    }
+
+    public boolean motionMagicDrive(double targetPosition) {
+
+        m_leftLeader.set(ControlMode.MotionMagic, targetPosition);
+        m_rightLeader.set(ControlMode.MotionMagic, targetPosition);
+
+        double m_currentLetfPos = getLeftEncoderPosition();
+        double m_currentRightPos = getRightEncoderPosition();
+
+        m_diffDrive.feedWatchdog();
+
+        return Math.abs(m_currentLetfPos - targetPosition) < kAllowableCloseLoopError && Math.abs(m_currentRightPos - targetPosition) < kAllowableCloseLoopError;
+    }
+
+    public void motionMagicStartConfigsTurn(boolean isCCWturn, double lengthInTicks){   
+
+        resetEncoders();
+		m_leftLeader.selectProfileSlot(kSlotTurning, kPID_TURN);
+		m_rightLeader.selectProfileSlot(kSlotTurning, kPID_TURN);
+		m_leftLeader.configMotionCruiseVelocity(1000, kTimeoutMs);
+		m_leftLeader.configMotionAcceleration(500, kTimeoutMs);
+		m_rightLeader.configMotionCruiseVelocity(1000, kTimeoutMs);
+		m_rightLeader.configMotionAcceleration(500, kTimeoutMs);
+
+	}
+
+    public boolean motionMagicTurn(double arc_in_ticks) {
+    
+        m_leftLeader.set(ControlMode.MotionMagic, arc_in_ticks);
+		m_rightLeader.set(ControlMode.MotionMagic, -arc_in_ticks);
+
+        double currentL = getLeftEncoderPosition();
+        double currentR = getRightEncoderPosition();
+
+        int targetTicks = Math.abs((int)arc_in_ticks);
+
+        m_diffDrive.feedWatchdog();
+
+        return (targetTicks - currentL) < kAllowableCloseLoopError && (targetTicks - currentR) < kAllowableCloseLoopError;
+    }
+
+    public void motionMagicEndConfigTurn(){
+		//m_leftLeader.configMotionCruiseVelocity(16636, kTimeoutMs);
+		//m_leftLeader.configMotionAcceleration(8318, kTimeoutMs);
+		//m_rightLeader.configMotionCruiseVelocity(16636, kTimeoutMs);
+		//m_rightLeader.configMotionAcceleration(8318, kTimeoutMs);
+	}
+
+    public double getLeftSetPoint() {
+        return m_leftSetpoint;
+    }
+
+    public double getRightSetPoint() {
+        return m_rightSetpoint;
+    }
+
+    public void resetDrivePIDValues(double kP, double kI, double kD, double kF) {
+
+        m_leftLeader.config_kP(kSlotDrive, kP);
+        m_leftLeader.config_kI(kSlotDrive, kI);
+        m_leftLeader.config_kD(kSlotDrive, kD);
+        m_leftLeader.config_kF(kSlotDrive, kF);
+
+    }
+
+    public void resetTurnPIDValues(double kP, double kI, double kD, double kF) {
+
+        m_leftLeader.config_kP(kSlotTurning, kP);
+        m_leftLeader.config_kI(kSlotTurning, kI);
+        m_leftLeader.config_kD(kSlotTurning, kD);
+        m_leftLeader.config_kF(kSlotTurning, kF);
+
+    }
+
+    public void updateDriveLimiters() {
+        m_driveAbsMax = m_driveAbsMaxEntry.getDouble(0);
+        m_secondsFromNeutral = m_secondsFromNeutralEntry.getDouble(0);
+
+        m_leftLeader.configOpenloopRamp(m_secondsFromNeutral);
+        m_leftFollower.configOpenloopRamp(m_secondsFromNeutral);
+        m_rightLeader.configOpenloopRamp(m_secondsFromNeutral);
+        m_rightFollower.configOpenloopRamp(m_secondsFromNeutral);
+    }
+
+    public void feedWatchdog() {
+        m_diffDrive.feed();
+    }
+    
+}


### PR DESCRIPTION
Some notes here:
I changed it to use more of the talon config object to reduce the number of slow canbus calls

Simplified the motion magic by resetting the encoders each time you use them, so should be more straight forward on the set point and getting to the target

I realized that not only were you lacking kF, and kP gains.  But the peak output was set to 0 for the Gains object, so that is fixed.

Updated all the commands to use the new DriveTrainTalonSRX class, I just named it that to make a nice easy merge for you.  There's nothing special about the class.

I removed a bunch of the auxiliary PID stuff that doesn't actually work very well on the TalonSRX, and I think it was just complicating the contstructor.

It builds and simulates without runtime issues, but I don't know if it actually works.  

NOTE: Double check the sensor phase after deploying before running it, just verify the sensor is in phase with the motor controller before actually firing the motion magic.